### PR TITLE
Ignore file names in diff compat check

### DIFF
--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -46,7 +46,7 @@ func TestDiffing(t *testing.T) {
 		"changed_field_label":      "changed label for field 'name' on message 'HelloRequest': LABEL_OPTIONAL -> LABEL_REPEATED",
 		"changed_field_name":       "changed name for field #1 on message 'HelloRequest': foo -> bar",
 		"changed_field_type":       "changed types for field 'name' on message 'HelloRequest': TYPE_STRING -> TYPE_BOOL",
-		"changed_package":          "changed package name: foo -> bar",
+		"changed_package":          "removed package 'foo'",
 		"changed_service_input":    "changed input type for method 'Invoke' on service 'Foo': .helloworld.FooRequest -> .helloworld.BarRequest",
 		"changed_service_output":   "changed output type for method 'Invoke' on service 'Foo': .helloworld.FooResponse -> .helloworld.BarResponse",
 		"removed_enum":             "removed enum 'FOO'",

--- a/diff/problem.go
+++ b/diff/problem.go
@@ -110,12 +110,12 @@ func (p ProblemRemovedMessage) String() string {
 	return fmt.Sprintf("removed message '%s'", p.Message)
 }
 
-type ProblemRemovedFile struct {
-	File string
+type ProblemRemovedPackage struct {
+	Package string
 }
 
-func (p ProblemRemovedFile) String() string {
-	return fmt.Sprintf("removed file '%s'", p.File)
+func (p ProblemRemovedPackage) String() string {
+	return fmt.Sprintf("removed package '%s'", p.Package)
 }
 
 type ProblemRemovedService struct {
@@ -137,14 +137,4 @@ type ProblemChangedServiceStreaming struct {
 func (p ProblemChangedServiceStreaming) String() string {
 	return fmt.Sprintf("changed %s streaming for method '%s' on service '%s': %t -> %t",
 		p.Side, p.Name, p.Service, p.OldStream != nil, p.NewStream != nil)
-}
-
-type ProblemChangedPackage struct {
-	File   *descriptor.FileDescriptorProto
-	OldPkg string
-	NewPkg string
-}
-
-func (p ProblemChangedPackage) String() string {
-	return fmt.Sprintf("changed package name: %s -> %s", p.OldPkg, p.NewPkg)
 }


### PR DESCRIPTION
The `diffFile(report, previous.File[0], current.File[0])` means master just didn't work with multiple files. In fixing that, it seemed to me like the logical thing to do was to ignore filenames completely, and validate backwards compatibility within each package instead. This could mean backwards compatibility is broken in the sense that downstream imports stop working, but I don't think that's the dangerous kind of compatibility breakage, because it's purely a compile-time thing and doesn't affect the ability to parse data on the wire.