### PR TITLE
Allow removing fields when name & number are reserved

### DIFF
--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -62,6 +62,8 @@ func TestDiffing(t *testing.T) {
 		"removed_message":          "removed message 'HelloRequest'",
 		"removed_service":          "removed service 'Foo'",
 		"removed_service_method":   "removed method 'Bar' from service 'Foo'",
+		"unreserved_name":          "un-reserved field name 'name' from message 'HelloRequest'",
+		"unreserved_number":        "un-reserved field number(s) in range 1 to 3 from message 'HelloRequest'",
 	}
 	for name, problem := range files {
 		t.Run(name, func(t *testing.T) {

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -96,4 +96,16 @@ func TestDiffing(t *testing.T) {
 			t.Fatal("%d unexpected problem reports", len(report.Changes))
 		}
 	})
+
+	t.Run("field removal with name & number reserved", func(t *testing.T) {
+		current := generateFileSet(t, "current", "removed_field_but_reserved")
+		previous := generateFileSet(t, "previous", "removed_field_but_reserved")
+		report, err := DiffSet(&previous, &current)
+		if err != nil {
+			t.Fatal("unexpected error %s", err)
+		}
+		if len(report.Changes) != 0 {
+			t.Fatal("%d unexpected problem reports", len(report.Changes))
+		}
+	})
 }

--- a/diff/problem.go
+++ b/diff/problem.go
@@ -138,3 +138,26 @@ func (p ProblemChangedServiceStreaming) String() string {
 	return fmt.Sprintf("changed %s streaming for method '%s' on service '%s': %t -> %t",
 		p.Side, p.Name, p.Service, p.OldStream != nil, p.NewStream != nil)
 }
+
+type ProblemUnreservedFieldName struct {
+	Message string
+	Name    string
+}
+
+func (p ProblemUnreservedFieldName) String() string {
+	return fmt.Sprintf("un-reserved field name '%s' from message '%s'", p.Name, p.Message)
+}
+
+type ProblemUnreservedFieldNumber struct {
+	Message string
+	Start   int32
+	End     int32
+}
+
+func (p ProblemUnreservedFieldNumber) String() string {
+	if p.End-p.Start > 1 {
+		return fmt.Sprintf("un-reserved field number(s) in range %d to %d from message '%s'", p.Start, p.End-1, p.Message)
+	} else {
+		return fmt.Sprintf("un-reserved field number %d from message '%s'", p.Start, p.Message)
+	}
+}

--- a/diff/testdata/current/removed_field_but_reserved.proto
+++ b/diff/testdata/current/removed_field_but_reserved.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package helloworld;
+
+message HelloRequest {
+  reserved 1;
+  reserved "name";
+}

--- a/diff/testdata/current/unreserved_name.proto
+++ b/diff/testdata/current/unreserved_name.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+package helloworld;
+
+message HelloRequest {
+}

--- a/diff/testdata/current/unreserved_number.proto
+++ b/diff/testdata/current/unreserved_number.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package helloworld;
+
+message HelloRequest {
+  reserved 1, 3;
+}

--- a/diff/testdata/previous/removed_field_but_reserved.proto
+++ b/diff/testdata/previous/removed_field_but_reserved.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package helloworld;
+
+message HelloRequest {
+  string name = 1;
+}
+

--- a/diff/testdata/previous/unreserved_name.proto
+++ b/diff/testdata/previous/unreserved_name.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package helloworld;
+
+message HelloRequest {
+  reserved "name";
+}

--- a/diff/testdata/previous/unreserved_number.proto
+++ b/diff/testdata/previous/unreserved_number.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package helloworld;
+
+message HelloRequest {
+  reserved 1 to 3;
+}


### PR DESCRIPTION
For corresponding safety, also ban removing reserved name or number (which would be equivalent to un-deletion).

Arguably this should be behind some sort of "allow removal" CLI flag, but as far as I know we only have the Stripe use case, where that would always be passed? Happy to add if desired, though.

