### PR TITLE
Add a check for when the fields of an enum change

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@
 
 ### Usage
 
-    protoc --lint_out=. helloworld.proto 
+    protoc --lint_out=. helloworld.proto
 
 ## protodiff
 
-Verify protocol buffer changes are backwards compatible.
+Verify protocol buffer changes are backwards compatible between both binary and
+JSON serialized representations.
 
 ### Installation
 

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -291,6 +291,21 @@ func diffEnum(report *Report, previous, current *descriptor.EnumDescriptorProto)
 			}
 		}
 	}
+
+	for _, name := range previous.Value {
+		_, exists := byname[*name.Name]
+		if !exists {
+			next, renamed := byvalue[*name.Number]
+			if renamed {
+				report.Add(ProblemChangeEnumName{
+					Enum:    *previous.Name,
+					Number:  *name.Number,
+					OldName: *name.Name,
+					NewName: *next.Name,
+				})
+			}
+		}
+	}
 }
 
 // Golang go-cmp

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -64,6 +64,7 @@ func TestDiffing(t *testing.T) {
 		"removed_service_method":   "removed method 'Bar' from service 'Foo'",
 		"unreserved_name":          "un-reserved field name 'name' from message 'HelloRequest'",
 		"unreserved_number":        "un-reserved field number(s) in range 1 to 3 from message 'HelloRequest'",
+		"changed_enum_name":        "changed name of field #1 on enum 'FOO': foo -> bat",
 	}
 	for name, problem := range files {
 		t.Run(name, func(t *testing.T) {
@@ -92,10 +93,10 @@ func TestDiffing(t *testing.T) {
 		reordered := generateFileSet(t, "current", "unchanged_import", "unchanged")
 		report, err := DiffSet(&files, &reordered)
 		if err != nil {
-			t.Fatal("unexpected error %s", err)
+			t.Fatalf("unexpected error %s", err)
 		}
 		if len(report.Changes) != 0 {
-			t.Fatal("%d unexpected problem reports", len(report.Changes))
+			t.Fatalf("%d unexpected problem reports", len(report.Changes))
 		}
 	})
 
@@ -104,10 +105,10 @@ func TestDiffing(t *testing.T) {
 		previous := generateFileSet(t, "previous", "removed_field_but_reserved")
 		report, err := DiffSet(&previous, &current)
 		if err != nil {
-			t.Fatal("unexpected error %s", err)
+			t.Fatalf("unexpected error %s", err)
 		}
 		if len(report.Changes) != 0 {
-			t.Fatal("%d unexpected problem reports", len(report.Changes))
+			t.Fatalf("%d unexpected problem reports", len(report.Changes))
 		}
 	})
 }

--- a/diff/problem.go
+++ b/diff/problem.go
@@ -94,6 +94,17 @@ func (p ProblemChangeEnumValue) String() string {
 	return fmt.Sprintf("changed value '%s' on enum '%s': %d -> %d", p.Name, p.Enum, p.OldValue, p.NewValue)
 }
 
+type ProblemChangeEnumName struct {
+	Enum    string
+	Number  int32
+	OldName string
+	NewName string
+}
+
+func (p ProblemChangeEnumName) String() string {
+	return fmt.Sprintf("changed name of field #%d on enum '%s': %s -> %s", p.Number, p.Enum, p.OldName, p.NewName)
+}
+
 type ProblemRemovedEnum struct {
 	Enum string
 }

--- a/diff/testdata/current/changed_enum_name.proto
+++ b/diff/testdata/current/changed_enum_name.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package helloworld;
+
+enum FOO {
+  bar = 0;
+  bat = 1;
+}

--- a/diff/testdata/previous/changed_enum_name.proto
+++ b/diff/testdata/previous/changed_enum_name.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package helloworld;
+
+enum FOO {
+  bar = 0;
+  foo = 1;
+}


### PR DESCRIPTION
This adds a check for when the name of an enum field changes between proto versions.

It also notes in the README that protodiff considers backwards compatibility for string-serialized proto.